### PR TITLE
This PR introduces a Dockerfile to run shiny with the R/test_App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@
 .Rproj.user
 R/.RData
 R/.Rhistory
+
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rocker/shiny
+
+RUN R -e "install.packages(c('ggplot2','annotate','Biobase','data.table','EMA','GEOmetadb','GEOquery','ggplot2','gplots','knitr','latex2exp','limma','mygene','R.utils'), repos='http://cran.rstudio.com/')"
+
+COPY R/test_App /srv/shiny-server/test_app
+
+CMD ["/usr/bin/shiny-server.sh"]


### PR DESCRIPTION
This Dockerfile sets up R shiny and relevant R libraries and installs the R/test_App into /src/shiny-server inside the container.

To run:
Build the docker image:
docker build -t callahantiff/ignorenet:0.1 .

Start the docker container:
docker run --rm -p 3838:3838 --name ignorenet callahantiff/ignorenet:0.1

Test app will be available at: http://localhost:3838/test_app